### PR TITLE
Fix, such that the standard analyzer honors the stop word list

### DIFF
--- a/src/analysis/analyzers.lisp
+++ b/src/analysis/analyzers.lisp
@@ -57,10 +57,12 @@
 
 (defmethod token-stream ((self standard-analyzer) field string-or-stream)
   (declare (ignore field))
-  (make-instance 'stop-filter
-		 :input (make-instance 'lowercase-filter
-				       :input (make-instance 'standard-tokenizer
-							     :input string-or-stream))))
+  (with-slots (stop-words) self
+    (make-instance 'stop-filter
+		   :input (make-instance 'lowercase-filter
+					 :input (make-instance 'standard-tokenizer
+							       :input string-or-stream))
+		   :stop-set stop-words)))
 
 
 (defclass per-field-analyzer-wrapper (analyzer)


### PR DESCRIPTION
The standard analyzer ignored the stop word list.  As far as I know it should honor it.
This very simple change adds this behavior.
- src/analysis/analyzers.lisp (token-stream): Added stop-words to the stop-filter.
