### PR TITLE
Fix AREF call in TERM-DOC-FREQS

### DIFF
--- a/src/search/index-searcher.lisp
+++ b/src/search/index-searcher.lisp
@@ -38,7 +38,7 @@
 (defmethod term-doc-freqs ((self index-searcher) (terms sequence))
   (let ((result (make-array (length terms))))
     (dosequence (i terms)
-      (setf (aref i result) 
+      (setf (aref result i) 
             (term-doc-freq self (aref terms i))))
     (values result)))
 


### PR DESCRIPTION
TERM-DOC-FREQS had an index variable and array variable transposed in AREF. This inhibited compilation on SBCL 1.1.13, which detected the problem via type inference. Changing the variables restores the ability to compile on SBCL 1.1.13.
